### PR TITLE
Adding openmc.materials support

### DIFF
--- a/openmc_data_downloader/utils.py
+++ b/openmc_data_downloader/utils.py
@@ -42,13 +42,17 @@ def expand_materials_to_isotopes(materials: list):
               'expand_materials_to_isotopes can not be performed.')
         return None
 
-    if isinstance(materials, list):
-        # check each entry is a openmc.Material
+    if isinstance(materials, openmc.Materials):
+        iterable_of_materials = materials 
+    elif isinstance(materials, list):
+        for material in materials:
+            if not isinstance(material, openmc.Material):
+                raise ValueError(
+                    'When passing a list then each entry in the list must be '
+                    'an openmc.Material. Not a', type(material))
         iterable_of_materials = materials
     elif isinstance(materials, openmc.Material):
         iterable_of_materials = [materials]
-    elif isinstance(materials, openmc.Materials):
-        iterable_of_materials = materials 
     else:
         raise ValueError(
             'materials must be of type openmc.Materials, openmc,Material or a '

--- a/openmc_data_downloader/utils.py
+++ b/openmc_data_downloader/utils.py
@@ -1,5 +1,5 @@
 
-import math
+
 import os
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -35,13 +35,28 @@ def set_enviromental_varible(cross_section_xml_path: Union[Path, str]) -> None:
 
 
 def expand_materials_to_isotopes(materials: list):
+    try:
+        import openmc
+    except ImportError:
+        print('openmc python package was not imported, '
+              'expand_materials_to_isotopes can not be performed.')
+        return None
 
-    if not isinstance(materials, list):
-        materials = [materials]
+    if isinstance(materials, list):
+        # check each entry is a openmc.Material
+        iterable_of_materials = materials
+    elif isinstance(materials, openmc.Material):
+        iterable_of_materials = [materials]
+    elif isinstance(materials, openmc.Materials):
+        iterable_of_materials = materials 
+    else:
+        raise ValueError(
+            'materials must be of type openmc.Materials, openmc,Material or a '
+            'list or openmc.Material. Not ', type(materials))
 
-    if len(materials) > 0:
+    if len(iterable_of_materials) > 0:
         isotopes_from_materials = []
-        for material in materials:
+        for material in iterable_of_materials:
             for nuc in material.nuclides:
                 isotopes_from_materials.append(nuc.name)
 
@@ -66,8 +81,7 @@ def just_in_time_library_generator(
         isotopes_from_elements = expand_elements_to_isotopes(elements)
         isotopes = list(set(isotopes + isotopes_from_elements))
 
-    isotopes_from_material_xml = expand_materials_xml_to_isotopes(
-        materials_xml)
+    isotopes_from_material_xml = expand_materials_xml_to_isotopes(materials_xml)
     isotopes = list(set(isotopes + isotopes_from_material_xml))
 
     isotopes_from_materials = expand_materials_to_isotopes(materials)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="openmc_data_downloader",
-    version="0.2.3",
+    version="0.2.4",
     summary="Download cross section h5 files for use in OpenMC",
     author="Jonathan Shimwell",
     author_email="mail@jshimwell.com",

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -204,3 +204,16 @@ class test_isotope_finding(unittest.TestCase):
             ValueError,
             incorrect_libraries_string
         )
+
+    def test_incorrect_expand_materials_to_isotopes_with_incorrect_args(self):
+        """Checks than an error is raised when incorrect values of materials
+        are passed"""
+
+        def incorrect_material_type():
+            expand_materials_to_isotopes(1)
+
+        def incorrect_materials_list_type():
+            expand_materials_to_isotopes([1, 2, 3])
+
+        self.assertRaises(ValueError, incorrect_material_type)
+        self.assertRaises(ValueError, incorrect_materials_list_type)

--- a/tests/test_use_in_openmc.py
+++ b/tests/test_use_in_openmc.py
@@ -27,7 +27,8 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
         my_mat_2 = openmc.Material()
         my_mat_2.add_nuclide('Pu240', 1.7512e-3)
         my_mat_2.add_nuclide('As75', 1.3752e-3)
-        mats = openmc.Materials([my_mat_1, my_mat_2]).export_to_xml()
+        mats = openmc.Materials([my_mat_1, my_mat_2])
+        mats.export_to_xml()
 
         # Create a sphere of my_mat
         surf_1 = openmc.Sphere(r=1)
@@ -69,351 +70,351 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
         assert len(list(Path('my_custom_nuclear_data_with_materials').glob('*.h5'))) == 3
      
 
-    # def test_simulation_with_destination(self):
-
-    #     os.system('rm *.h5')
-    #     os.system('rm my_custom_nuclear_data_dir/*.h5')
-
-    #     # Define material
-    #     my_mat = openmc.openmc.Material()
-    #     my_mat.add_nuclide('Pu239', 3.7047e-2)
-    #     my_mat.add_nuclide('Pu240', 1.7512e-3)
-    #     my_mat.add_nuclide('As75', 1.3752e-3)
-    #     openmc.openmc.Materials([my_mat]).export_to_xml()
-
-    #     # Create a sphere of my_mat
-    #     surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
-    #     main_cell = openmc.Cell(fill=my_mat, region=-surf)
-    #     openmc.Geometry([main_cell]).export_to_xml()
-
-    #     # Define settings for the simulation
-    #     settings = openmc.Settings()
-    #     settings.particles = 10
-    #     settings.batches = 2
-    #     settings.inactive = 0
-    #     center = (0., 0., 0.)
-    #     settings.source = openmc.Source(space=openmc.stats.Point(center))
-    #     settings.export_to_xml()
-
-    #     # this clears the enviromental varible just to be sure that current
-    #     # system settings are not being used
-    #     os.environ["OPENMC_CROSS_SECTIONS"] = ''
-
-    #     just_in_time_library_generator(
-    #         destination='my_custom_nuclear_data_dir',
-    #         libraries=['TENDL-2019'],
-    #         materials=my_mat,
-    #         set_OPENMC_CROSS_SECTIONS=True
-    #     )
-
-    #     os.system('echo $OPENMC_CROSS_SECTIONS')
-    #     openmc.run()
-
-    #     assert Path('my_custom_nuclear_data_dir/TENDL-2019_Pu239.h5').is_file()
-    #     assert Path('my_custom_nuclear_data_dir/TENDL-2019_Pu240.h5').is_file()
-    #     assert Path('my_custom_nuclear_data_dir/TENDL-2019_As75.h5').is_file()
-
-    #     assert Path('summary.h5').is_file()
-    #     assert Path('statepoint.2.h5').is_file()
-
-    #     assert len(list(Path('my_custom_nuclear_data_dir').glob('*.h5'))) == 3
-
-    # def test_photon_simulation_with_single_mat(self):
-
-    #     os.system('rm *.h5')
-
-    #     # Define material
-    #     my_mat = openmc.openmc.Material()
-    #     my_mat.add_element('Fe', 1)
-    #     openmc.openmc.Materials([my_mat]).export_to_xml()
-
-    #     # Create a sphere of my_mat
-    #     surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
-    #     main_cell = openmc.Cell(fill=my_mat, region=-surf)
-    #     openmc.Geometry([main_cell]).export_to_xml()
-
-    #     # Define settings for the simulation
-    #     settings = openmc.Settings()
-    #     settings.particles = 10
-    #     settings.batches = 2
-    #     settings.inactive = 0
-    #     settings.run_mode = 'fixed source'
-    #     settings.photon_transport = True
-
-    #     source = openmc.Source()
-    #     source.space = openmc.stats.Point((0, 0, 0))
-    #     source.angle = openmc.stats.Isotropic()
-    #     # This is a Co60 source, see the task on sources to understand it
-    #     source.energy = openmc.stats.Discrete([1.1732e6], [1.])
-    #     source.particle = 'photon'
-
-    #     settings.source = source
-    #     settings.export_to_xml()
-
-    #     # this clears the enviromental varible just to be sure that current
-    #     # system settings are not being used
-    #     os.environ["OPENMC_CROSS_SECTIONS"] = ''
-
-    #     just_in_time_library_generator(
-    #         libraries=['FENDL-3.1d'],
-    #         materials=my_mat,
-    #         # TODO find out why neutrons are needed here
-    #         particles=['photon', 'neutron'],
-    #         set_OPENMC_CROSS_SECTIONS=True
-    #     )
-
-    #     os.system('echo $OPENMC_CROSS_SECTIONS')
-    #     openmc.run()
-
-    #     assert Path('FENDL-3.1d_Fe.h5').is_file()
-
-    #     assert Path('summary.h5').is_file()
-    #     assert Path('statepoint.2.h5').is_file()
-
-    #     # normally 3 if just photons used
-    #     assert len(list(Path('.').glob('*.h5'))) == 7
-
-    # def test_photon_neutron_simulation_with_single_mat(self):
-
-    #     os.system('rm *.h5')
-
-    #     # Define material
-    #     my_mat = openmc.openmc.Material()
-    #     my_mat.add_element('Fe', 1)
-    #     openmc.openmc.Materials([my_mat]).export_to_xml()
-
-    #     # Create a sphere of my_mat
-    #     surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
-    #     main_cell = openmc.Cell(fill=my_mat, region=-surf)
-    #     openmc.Geometry([main_cell]).export_to_xml()
-
-    #     # Define settings for the simulation
-    #     settings = openmc.Settings()
-    #     settings.particles = 10
-    #     settings.batches = 2
-    #     settings.inactive = 0
-    #     settings.photon_transport = True
-    #     center = (0., 0., 0.)
-    #     settings.source = openmc.Source(space=openmc.stats.Point(center))
-    #     settings.run_mode = 'fixed source'
-    #     settings.export_to_xml()
-
-    #     # this clears the enviromental varible just to be sure that current
-    #     # system settings are not being used
-    #     os.environ["OPENMC_CROSS_SECTIONS"] = ''
-
-    #     just_in_time_library_generator(
-    #         libraries=['FENDL-3.1d'],
-    #         materials=my_mat,
-    #         particles=['neutron', 'photon'],
-    #         set_OPENMC_CROSS_SECTIONS=True
-    #     )
-
-    #     os.system('echo $OPENMC_CROSS_SECTIONS')
-    #     openmc.run()
-
-    #     assert Path('FENDL-3.1d_Fe54.h5').is_file()
-    #     assert Path('FENDL-3.1d_Fe56.h5').is_file()
-    #     assert Path('FENDL-3.1d_Fe57.h5').is_file()
-    #     assert Path('FENDL-3.1d_Fe58.h5').is_file()
-    #     assert Path('FENDL-3.1d_Fe.h5').is_file()
-
-    #     assert Path('summary.h5').is_file()
-    #     assert Path('statepoint.2.h5').is_file()
-    #     assert len(list(Path('.').glob('*.h5'))) == 7  # summary and statepoint
-
-    # def test_simulation_with_single_mat(self):
-
-    #     os.system('rm *.h5')
-
-    #     # Define material
-    #     my_mat = openmc.openmc.Material()
-    #     my_mat.add_nuclide('Pu239', 3.7047e-2)
-    #     my_mat.add_nuclide('Pu240', 1.7512e-3)
-    #     my_mat.add_nuclide('As75', 1.3752e-3)
-    #     openmc.openmc.Materials([my_mat]).export_to_xml()
-
-    #     # Create a sphere of my_mat
-    #     surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
-    #     main_cell = openmc.Cell(fill=my_mat, region=-surf)
-    #     openmc.Geometry([main_cell]).export_to_xml()
-
-    #     # Define settings for the simulation
-    #     settings = openmc.Settings()
-    #     settings.particles = 10
-    #     settings.batches = 2
-    #     settings.inactive = 0
-    #     center = (0., 0., 0.)
-    #     settings.source = openmc.Source(space=openmc.stats.Point(center))
-    #     settings.export_to_xml()
-
-    #     # this clears the enviromental varible just to be sure that current
-    #     # system settings are not being used
-    #     os.environ["OPENMC_CROSS_SECTIONS"] = ''
-
-    #     just_in_time_library_generator(
-    #         libraries=['TENDL-2019'],
-    #         materials=my_mat,
-    #         particles='neutron',
-    #         set_OPENMC_CROSS_SECTIONS=True)
-
-    #     os.system('echo $OPENMC_CROSS_SECTIONS')
-    #     openmc.run()
-
-    #     assert Path('TENDL-2019_Pu239.h5').is_file()
-    #     assert Path('TENDL-2019_Pu240.h5').is_file()
-    #     assert Path('TENDL-2019_As75.h5').is_file()
-
-    #     assert Path('summary.h5').is_file()
-    #     assert Path('statepoint.2.h5').is_file()
-    #     assert len(list(Path('.').glob('*.h5'))) == 5  # summary and statepoint
-
-    # def test_wmp_simulation_with_single_mat(self):
-
-    #     os.system('rm *.h5')
-
-    #     # Define material
-    #     my_mat = openmc.openmc.Material()
-    #     my_mat.add_nuclide('P31', 1)
-    #     my_mat.temperature = 400  # main_cell used instead
-    #     openmc.openmc.Materials([my_mat]).export_to_xml()
-
-    #     # Create a sphere of my_mat
-    #     surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
-    #     main_cell = openmc.Cell(fill=my_mat, region=-surf)
-    #     main_cell.temperature = 400
-    #     openmc.Geometry([main_cell]).export_to_xml()
-
-    #     # Define settings for the simulation
-    #     settings = openmc.Settings()
-    #     settings.particles = 10
-    #     settings.batches = 2
-    #     settings.inactive = 0
-    #     settings.photon_transport = False
-    #     center = (0., 0., 0.)
-    #     settings.source = openmc.Source(space=openmc.stats.Point(center))
-    #     settings.run_mode = 'fixed source'
-    #     settings.temperature = {'multipole': True}
-    #     settings.export_to_xml()
-
-    #     # this clears the enviromental varible just to be sure that current
-    #     # system settings are not being used
-    #     os.environ["OPENMC_CROSS_SECTIONS"] = ''
-
-    #     just_in_time_library_generator(
-    #         # 'ENDFB-7.1-NNDC' is needed as WMP simulations appear to require
-    #         # non WMP cross sections as well when simulating
-    #         # https://openmc.discourse.group/t/minimal-wmp-simulation-with-minimal-cross-section-xml/1100/7
-    #         libraries=['ENDFB-7.1-NNDC', 'ENDFB-7.1-WMP'],
-    #         materials=my_mat,
-    #         particles='neutron',
-    #         set_OPENMC_CROSS_SECTIONS=True)
-
-    #     os.system('echo $OPENMC_CROSS_SECTIONS')
-    #     openmc.run()
-
-    #     assert Path('ENDFB-7.1-WMP_P31.h5').is_file()
-
-    #     assert Path('summary.h5').is_file()
-    #     assert Path('statepoint.2.h5').is_file()
-    #     assert len(list(Path('.').glob('*.h5'))) == 3
-
-    # def test_simulation_with_single_mat_list(self):
-
-    #     os.system('rm *.h5')
-
-    #     # Define material
-    #     my_mat = openmc.openmc.Material()
-    #     my_mat.add_nuclide('Pu239', 3.7047e-2)
-    #     my_mat.add_nuclide('Pu240', 1.7512e-3)
-    #     my_mat.add_nuclide('As75', 1.3752e-3)
-    #     openmc.openmc.Materials([my_mat]).export_to_xml()
-
-    #     # Create a sphere of my_mat
-    #     surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
-    #     main_cell = openmc.Cell(fill=my_mat, region=-surf)
-    #     openmc.Geometry([main_cell]).export_to_xml()
-
-    #     # Define settings for the simulation
-    #     settings = openmc.Settings()
-    #     settings.particles = 10
-    #     settings.batches = 2
-    #     settings.inactive = 0
-    #     center = (0., 0., 0.)
-    #     settings.source = openmc.Source(space=openmc.stats.Point(center))
-    #     settings.export_to_xml()
-
-    #     # this clears the enviromental varible just to be sure that current
-    #     # system settings are not being used
-    #     os.environ["OPENMC_CROSS_SECTIONS"] = ''
-
-    #     just_in_time_library_generator(
-    #         libraries=['TENDL-2019'],
-    #         materials=[my_mat],
-    #         particles='neutron',
-    #         set_OPENMC_CROSS_SECTIONS=True)
-
-    #     os.system('echo $OPENMC_CROSS_SECTIONS')
-    #     openmc.run()
-
-    #     assert Path('TENDL-2019_Pu239.h5').is_file()
-    #     assert Path('TENDL-2019_Pu240.h5').is_file()
-    #     assert Path('TENDL-2019_As75.h5').is_file()
-
-    #     assert Path('summary.h5').is_file()
-    #     assert Path('statepoint.2.h5').is_file()
-
-    #     assert len(list(Path('.').glob('*.h5'))) == 5  # summary and statepoint
-
-    # def test_simulation_with_multi_mat_list(self):
-
-    #     os.system('rm *.h5')
-
-    #     # Define material
-    #     my_mat1 = openmc.openmc.Material()
-    #     my_mat1.add_nuclide('Pu239', 3.7047e-2)
-    #     my_mat1.add_nuclide('Pu240', 1.7512e-3)
-
-    #     my_mat2 = openmc.openmc.Material()
-    #     my_mat2.add_element('As', 1.3752e-3)
-    #     openmc.openmc.Materials([my_mat1, my_mat2]).export_to_xml()
-
-    #     # Create a sphere of my_mat
-    #     surf1 = openmc.Sphere(r=1)
-    #     surf2 = openmc.Sphere(r=6, boundary_type='vacuum')
-    #     main_cell = openmc.Cell(fill=my_mat1, region=-surf1)
-    #     outer_cell = openmc.Cell(fill=my_mat2, region=+surf1 & -surf2)
-    #     universe = openmc.Universe(cells=[main_cell, outer_cell])
-    #     openmc.Geometry(universe).export_to_xml()
-
-    #     # Define settings for the simulation
-    #     settings = openmc.Settings()
-    #     settings.particles = 10
-    #     settings.batches = 2
-    #     settings.inactive = 0
-    #     center = (0., 0., 0.)
-    #     settings.source = openmc.Source(space=openmc.stats.Point(center))
-    #     settings.export_to_xml()
-
-    #     # this clears the enviromental varible just to be sure that current
-    #     # system settings are not being used
-    #     os.environ["OPENMC_CROSS_SECTIONS"] = ''
-
-    #     just_in_time_library_generator(
-    #         libraries=['TENDL-2019'],
-    #         materials=[
-    #             my_mat1,
-    #             my_mat2],
-    #         set_OPENMC_CROSS_SECTIONS=True)
-
-    #     os.system('echo $OPENMC_CROSS_SECTIONS')
-    #     openmc.run()
-
-    #     assert Path('TENDL-2019_Pu239.h5').is_file()
-    #     assert Path('TENDL-2019_Pu240.h5').is_file()
-    #     assert Path('TENDL-2019_As75.h5').is_file()
-
-    #     assert Path('summary.h5').is_file()
-    #     assert Path('statepoint.2.h5').is_file()
-
-    #     assert len(list(Path('.').glob('*.h5'))) == 5  # summary and statepoint
+    def test_simulation_with_destination(self):
+
+        os.system('rm *.h5')
+        os.system('rm my_custom_nuclear_data_dir/*.h5')
+
+        # Define material
+        my_mat = openmc.openmc.Material()
+        my_mat.add_nuclide('Pu239', 3.7047e-2)
+        my_mat.add_nuclide('Pu240', 1.7512e-3)
+        my_mat.add_nuclide('As75', 1.3752e-3)
+        openmc.openmc.Materials([my_mat]).export_to_xml()
+
+        # Create a sphere of my_mat
+        surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
+        main_cell = openmc.Cell(fill=my_mat, region=-surf)
+        openmc.Geometry([main_cell]).export_to_xml()
+
+        # Define settings for the simulation
+        settings = openmc.Settings()
+        settings.particles = 10
+        settings.batches = 2
+        settings.inactive = 0
+        center = (0., 0., 0.)
+        settings.source = openmc.Source(space=openmc.stats.Point(center))
+        settings.export_to_xml()
+
+        # this clears the enviromental varible just to be sure that current
+        # system settings are not being used
+        os.environ["OPENMC_CROSS_SECTIONS"] = ''
+
+        just_in_time_library_generator(
+            destination='my_custom_nuclear_data_dir',
+            libraries=['TENDL-2019'],
+            materials=my_mat,
+            set_OPENMC_CROSS_SECTIONS=True
+        )
+
+        os.system('echo $OPENMC_CROSS_SECTIONS')
+        openmc.run()
+
+        assert Path('my_custom_nuclear_data_dir/TENDL-2019_Pu239.h5').is_file()
+        assert Path('my_custom_nuclear_data_dir/TENDL-2019_Pu240.h5').is_file()
+        assert Path('my_custom_nuclear_data_dir/TENDL-2019_As75.h5').is_file()
+
+        assert Path('summary.h5').is_file()
+        assert Path('statepoint.2.h5').is_file()
+
+        assert len(list(Path('my_custom_nuclear_data_dir').glob('*.h5'))) == 3
+
+    def test_photon_simulation_with_single_mat(self):
+
+        os.system('rm *.h5')
+
+        # Define material
+        my_mat = openmc.openmc.Material()
+        my_mat.add_element('Fe', 1)
+        openmc.openmc.Materials([my_mat]).export_to_xml()
+
+        # Create a sphere of my_mat
+        surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
+        main_cell = openmc.Cell(fill=my_mat, region=-surf)
+        openmc.Geometry([main_cell]).export_to_xml()
+
+        # Define settings for the simulation
+        settings = openmc.Settings()
+        settings.particles = 10
+        settings.batches = 2
+        settings.inactive = 0
+        settings.run_mode = 'fixed source'
+        settings.photon_transport = True
+
+        source = openmc.Source()
+        source.space = openmc.stats.Point((0, 0, 0))
+        source.angle = openmc.stats.Isotropic()
+        # This is a Co60 source, see the task on sources to understand it
+        source.energy = openmc.stats.Discrete([1.1732e6], [1.])
+        source.particle = 'photon'
+
+        settings.source = source
+        settings.export_to_xml()
+
+        # this clears the enviromental varible just to be sure that current
+        # system settings are not being used
+        os.environ["OPENMC_CROSS_SECTIONS"] = ''
+
+        just_in_time_library_generator(
+            libraries=['FENDL-3.1d'],
+            materials=my_mat,
+            # TODO find out why neutrons are needed here
+            particles=['photon', 'neutron'],
+            set_OPENMC_CROSS_SECTIONS=True
+        )
+
+        os.system('echo $OPENMC_CROSS_SECTIONS')
+        openmc.run()
+
+        assert Path('FENDL-3.1d_Fe.h5').is_file()
+
+        assert Path('summary.h5').is_file()
+        assert Path('statepoint.2.h5').is_file()
+
+        # normally 3 if just photons used
+        assert len(list(Path('.').glob('*.h5'))) == 7
+
+    def test_photon_neutron_simulation_with_single_mat(self):
+
+        os.system('rm *.h5')
+
+        # Define material
+        my_mat = openmc.openmc.Material()
+        my_mat.add_element('Fe', 1)
+        openmc.openmc.Materials([my_mat]).export_to_xml()
+
+        # Create a sphere of my_mat
+        surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
+        main_cell = openmc.Cell(fill=my_mat, region=-surf)
+        openmc.Geometry([main_cell]).export_to_xml()
+
+        # Define settings for the simulation
+        settings = openmc.Settings()
+        settings.particles = 10
+        settings.batches = 2
+        settings.inactive = 0
+        settings.photon_transport = True
+        center = (0., 0., 0.)
+        settings.source = openmc.Source(space=openmc.stats.Point(center))
+        settings.run_mode = 'fixed source'
+        settings.export_to_xml()
+
+        # this clears the enviromental varible just to be sure that current
+        # system settings are not being used
+        os.environ["OPENMC_CROSS_SECTIONS"] = ''
+
+        just_in_time_library_generator(
+            libraries=['FENDL-3.1d'],
+            materials=my_mat,
+            particles=['neutron', 'photon'],
+            set_OPENMC_CROSS_SECTIONS=True
+        )
+
+        os.system('echo $OPENMC_CROSS_SECTIONS')
+        openmc.run()
+
+        assert Path('FENDL-3.1d_Fe54.h5').is_file()
+        assert Path('FENDL-3.1d_Fe56.h5').is_file()
+        assert Path('FENDL-3.1d_Fe57.h5').is_file()
+        assert Path('FENDL-3.1d_Fe58.h5').is_file()
+        assert Path('FENDL-3.1d_Fe.h5').is_file()
+
+        assert Path('summary.h5').is_file()
+        assert Path('statepoint.2.h5').is_file()
+        assert len(list(Path('.').glob('*.h5'))) == 7  # summary and statepoint
+
+    def test_simulation_with_single_mat(self):
+
+        os.system('rm *.h5')
+
+        # Define material
+        my_mat = openmc.openmc.Material()
+        my_mat.add_nuclide('Pu239', 3.7047e-2)
+        my_mat.add_nuclide('Pu240', 1.7512e-3)
+        my_mat.add_nuclide('As75', 1.3752e-3)
+        openmc.openmc.Materials([my_mat]).export_to_xml()
+
+        # Create a sphere of my_mat
+        surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
+        main_cell = openmc.Cell(fill=my_mat, region=-surf)
+        openmc.Geometry([main_cell]).export_to_xml()
+
+        # Define settings for the simulation
+        settings = openmc.Settings()
+        settings.particles = 10
+        settings.batches = 2
+        settings.inactive = 0
+        center = (0., 0., 0.)
+        settings.source = openmc.Source(space=openmc.stats.Point(center))
+        settings.export_to_xml()
+
+        # this clears the enviromental varible just to be sure that current
+        # system settings are not being used
+        os.environ["OPENMC_CROSS_SECTIONS"] = ''
+
+        just_in_time_library_generator(
+            libraries=['TENDL-2019'],
+            materials=my_mat,
+            particles='neutron',
+            set_OPENMC_CROSS_SECTIONS=True)
+
+        os.system('echo $OPENMC_CROSS_SECTIONS')
+        openmc.run()
+
+        assert Path('TENDL-2019_Pu239.h5').is_file()
+        assert Path('TENDL-2019_Pu240.h5').is_file()
+        assert Path('TENDL-2019_As75.h5').is_file()
+
+        assert Path('summary.h5').is_file()
+        assert Path('statepoint.2.h5').is_file()
+        assert len(list(Path('.').glob('*.h5'))) == 5  # summary and statepoint
+
+    def test_wmp_simulation_with_single_mat(self):
+
+        os.system('rm *.h5')
+
+        # Define material
+        my_mat = openmc.openmc.Material()
+        my_mat.add_nuclide('P31', 1)
+        my_mat.temperature = 400  # main_cell used instead
+        openmc.openmc.Materials([my_mat]).export_to_xml()
+
+        # Create a sphere of my_mat
+        surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
+        main_cell = openmc.Cell(fill=my_mat, region=-surf)
+        main_cell.temperature = 400
+        openmc.Geometry([main_cell]).export_to_xml()
+
+        # Define settings for the simulation
+        settings = openmc.Settings()
+        settings.particles = 10
+        settings.batches = 2
+        settings.inactive = 0
+        settings.photon_transport = False
+        center = (0., 0., 0.)
+        settings.source = openmc.Source(space=openmc.stats.Point(center))
+        settings.run_mode = 'fixed source'
+        settings.temperature = {'multipole': True}
+        settings.export_to_xml()
+
+        # this clears the enviromental varible just to be sure that current
+        # system settings are not being used
+        os.environ["OPENMC_CROSS_SECTIONS"] = ''
+
+        just_in_time_library_generator(
+            # 'ENDFB-7.1-NNDC' is needed as WMP simulations appear to require
+            # non WMP cross sections as well when simulating
+            # https://openmc.discourse.group/t/minimal-wmp-simulation-with-minimal-cross-section-xml/1100/7
+            libraries=['ENDFB-7.1-NNDC', 'ENDFB-7.1-WMP'],
+            materials=my_mat,
+            particles='neutron',
+            set_OPENMC_CROSS_SECTIONS=True)
+
+        os.system('echo $OPENMC_CROSS_SECTIONS')
+        openmc.run()
+
+        assert Path('ENDFB-7.1-WMP_P31.h5').is_file()
+
+        assert Path('summary.h5').is_file()
+        assert Path('statepoint.2.h5').is_file()
+        assert len(list(Path('.').glob('*.h5'))) == 3
+
+    def test_simulation_with_single_mat_list(self):
+
+        os.system('rm *.h5')
+
+        # Define material
+        my_mat = openmc.openmc.Material()
+        my_mat.add_nuclide('Pu239', 3.7047e-2)
+        my_mat.add_nuclide('Pu240', 1.7512e-3)
+        my_mat.add_nuclide('As75', 1.3752e-3)
+        openmc.openmc.Materials([my_mat]).export_to_xml()
+
+        # Create a sphere of my_mat
+        surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
+        main_cell = openmc.Cell(fill=my_mat, region=-surf)
+        openmc.Geometry([main_cell]).export_to_xml()
+
+        # Define settings for the simulation
+        settings = openmc.Settings()
+        settings.particles = 10
+        settings.batches = 2
+        settings.inactive = 0
+        center = (0., 0., 0.)
+        settings.source = openmc.Source(space=openmc.stats.Point(center))
+        settings.export_to_xml()
+
+        # this clears the enviromental varible just to be sure that current
+        # system settings are not being used
+        os.environ["OPENMC_CROSS_SECTIONS"] = ''
+
+        just_in_time_library_generator(
+            libraries=['TENDL-2019'],
+            materials=[my_mat],
+            particles='neutron',
+            set_OPENMC_CROSS_SECTIONS=True)
+
+        os.system('echo $OPENMC_CROSS_SECTIONS')
+        openmc.run()
+
+        assert Path('TENDL-2019_Pu239.h5').is_file()
+        assert Path('TENDL-2019_Pu240.h5').is_file()
+        assert Path('TENDL-2019_As75.h5').is_file()
+
+        assert Path('summary.h5').is_file()
+        assert Path('statepoint.2.h5').is_file()
+
+        assert len(list(Path('.').glob('*.h5'))) == 5  # summary and statepoint
+
+    def test_simulation_with_multi_mat_list(self):
+
+        os.system('rm *.h5')
+
+        # Define material
+        my_mat1 = openmc.openmc.Material()
+        my_mat1.add_nuclide('Pu239', 3.7047e-2)
+        my_mat1.add_nuclide('Pu240', 1.7512e-3)
+
+        my_mat2 = openmc.openmc.Material()
+        my_mat2.add_element('As', 1.3752e-3)
+        openmc.openmc.Materials([my_mat1, my_mat2]).export_to_xml()
+
+        # Create a sphere of my_mat
+        surf1 = openmc.Sphere(r=1)
+        surf2 = openmc.Sphere(r=6, boundary_type='vacuum')
+        main_cell = openmc.Cell(fill=my_mat1, region=-surf1)
+        outer_cell = openmc.Cell(fill=my_mat2, region=+surf1 & -surf2)
+        universe = openmc.Universe(cells=[main_cell, outer_cell])
+        openmc.Geometry(universe).export_to_xml()
+
+        # Define settings for the simulation
+        settings = openmc.Settings()
+        settings.particles = 10
+        settings.batches = 2
+        settings.inactive = 0
+        center = (0., 0., 0.)
+        settings.source = openmc.Source(space=openmc.stats.Point(center))
+        settings.export_to_xml()
+
+        # this clears the enviromental varible just to be sure that current
+        # system settings are not being used
+        os.environ["OPENMC_CROSS_SECTIONS"] = ''
+
+        just_in_time_library_generator(
+            libraries=['TENDL-2019'],
+            materials=[
+                my_mat1,
+                my_mat2],
+            set_OPENMC_CROSS_SECTIONS=True)
+
+        os.system('echo $OPENMC_CROSS_SECTIONS')
+        openmc.run()
+
+        assert Path('TENDL-2019_Pu239.h5').is_file()
+        assert Path('TENDL-2019_Pu240.h5').is_file()
+        assert Path('TENDL-2019_As75.h5').is_file()
+
+        assert Path('summary.h5').is_file()
+        assert Path('statepoint.2.h5').is_file()
+
+        assert len(list(Path('.').glob('*.h5'))) == 5  # summary and statepoint

--- a/tests/test_use_in_openmc.py
+++ b/tests/test_use_in_openmc.py
@@ -49,7 +49,7 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
 
         # this clears the enviromental varible just to be sure that current
         # system settings are not being used
-        os.environ["OPENMC_CROSS_SECTIONS"] = ''
+        del os.environ["OPENMC_CROSS_SECTIONS"]
 
         just_in_time_library_generator(
             destination='my_custom_nuclear_data_with_materials',
@@ -103,7 +103,7 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
 
         # this clears the enviromental varible just to be sure that current
         # system settings are not being used
-        os.environ["OPENMC_CROSS_SECTIONS"] = ''
+        del os.environ["OPENMC_CROSS_SECTIONS"]
 
         just_in_time_library_generator(
             destination='my_custom_nuclear_data_dir',
@@ -128,10 +128,14 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
 
         os.system('rm *.h5')
 
+        # this clears the enviromental varible just to be sure that current
+        # system settings are not being used
+        del os.environ["OPENMC_CROSS_SECTIONS"]
+
         # Define material
-        my_mat = openmc.openmc.Material()
+        my_mat = openmc.Material()
         my_mat.add_element('Fe', 1)
-        openmc.openmc.Materials([my_mat]).export_to_xml()
+        openmc.Materials([my_mat]).export_to_xml()
 
         # Create a sphere of my_mat
         surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
@@ -156,10 +160,6 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
         settings.source = source
         settings.export_to_xml()
 
-        # this clears the enviromental varible just to be sure that current
-        # system settings are not being used
-        os.environ["OPENMC_CROSS_SECTIONS"] = ''
-
         just_in_time_library_generator(
             libraries=['FENDL-3.1d'],
             materials=my_mat,
@@ -183,6 +183,10 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
 
         os.system('rm *.h5')
 
+        # this clears the enviromental varible just to be sure that current
+        # system settings are not being used
+        del os.environ["OPENMC_CROSS_SECTIONS"]
+
         # Define material
         my_mat = openmc.openmc.Material()
         my_mat.add_element('Fe', 1)
@@ -203,10 +207,6 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
         settings.source = openmc.Source(space=openmc.stats.Point(center))
         settings.run_mode = 'fixed source'
         settings.export_to_xml()
-
-        # this clears the enviromental varible just to be sure that current
-        # system settings are not being used
-        os.environ["OPENMC_CROSS_SECTIONS"] = ''
 
         just_in_time_library_generator(
             libraries=['FENDL-3.1d'],
@@ -232,6 +232,10 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
 
         os.system('rm *.h5')
 
+        # this clears the enviromental varible just to be sure that current
+        # system settings are not being used
+        del os.environ["OPENMC_CROSS_SECTIONS"]
+
         # Define material
         my_mat = openmc.openmc.Material()
         my_mat.add_nuclide('Pu239', 3.7047e-2)
@@ -253,10 +257,6 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
         settings.source = openmc.Source(space=openmc.stats.Point(center))
         settings.export_to_xml()
 
-        # this clears the enviromental varible just to be sure that current
-        # system settings are not being used
-        os.environ["OPENMC_CROSS_SECTIONS"] = ''
-
         just_in_time_library_generator(
             libraries=['TENDL-2019'],
             materials=my_mat,
@@ -277,6 +277,10 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
     def test_wmp_simulation_with_single_mat(self):
 
         os.system('rm *.h5')
+
+        # this clears the enviromental varible just to be sure that current
+        # system settings are not being used
+        del os.environ["OPENMC_CROSS_SECTIONS"]
 
         # Define material
         my_mat = openmc.openmc.Material()
@@ -302,10 +306,6 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
         settings.temperature = {'multipole': True}
         settings.export_to_xml()
 
-        # this clears the enviromental varible just to be sure that current
-        # system settings are not being used
-        os.environ["OPENMC_CROSS_SECTIONS"] = ''
-
         just_in_time_library_generator(
             # 'ENDFB-7.1-NNDC' is needed as WMP simulations appear to require
             # non WMP cross sections as well when simulating
@@ -328,6 +328,10 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
 
         os.system('rm *.h5')
 
+        # this clears the enviromental varible just to be sure that current
+        # system settings are not being used
+        del os.environ["OPENMC_CROSS_SECTIONS"]
+
         # Define material
         my_mat = openmc.openmc.Material()
         my_mat.add_nuclide('Pu239', 3.7047e-2)
@@ -348,10 +352,6 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
         center = (0., 0., 0.)
         settings.source = openmc.Source(space=openmc.stats.Point(center))
         settings.export_to_xml()
-
-        # this clears the enviromental varible just to be sure that current
-        # system settings are not being used
-        os.environ["OPENMC_CROSS_SECTIONS"] = ''
 
         just_in_time_library_generator(
             libraries=['TENDL-2019'],
@@ -374,6 +374,10 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
     def test_simulation_with_multi_mat_list(self):
 
         os.system('rm *.h5')
+
+        # this clears the enviromental varible just to be sure that current
+        # system settings are not being used
+        del os.environ["OPENMC_CROSS_SECTIONS"]
 
         # Define material
         my_mat1 = openmc.openmc.Material()
@@ -401,10 +405,6 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
         settings.source = openmc.Source(space=openmc.stats.Point(center))
         settings.export_to_xml()
 
-        # this clears the enviromental varible just to be sure that current
-        # system settings are not being used
-        os.environ["OPENMC_CROSS_SECTIONS"] = ''
-
         just_in_time_library_generator(
             libraries=['TENDL-2019'],
             materials=[
@@ -423,18 +423,3 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
         assert Path('statepoint.2.h5').is_file()
 
         assert len(list(Path('.').glob('*.h5'))) == 5  # summary and statepoint
-
-    def test_incorrect_expand_materials_to_isotopes_with_inccorect_args(self):
-        """Checks than an error is raised when incorrect values of materials
-        are passed"""
-
-        def incorrect_material_type():
-            openmc_data_downloader.expand_materials_to_isotopes(1)
-
-        self.assertRaises(incorrect_material_type)
-
-        def incorrect_materials_list_type():
-            openmc_data_downloader.expand_materials_to_isotopes([1, 2, 3])
-
-        self.assertRaises(incorrect_material_type, ValueError)
-        self.assertRaises(incorrect_materials_list_type, ValueError)

--- a/tests/test_use_in_openmc.py
+++ b/tests/test_use_in_openmc.py
@@ -13,27 +13,33 @@ from openmc_data_downloader import just_in_time_library_generator
 
 class test_usage_with_openmc_python_api(unittest.TestCase):
 
-    def test_simulation_with_destination(self):
+    def test_materials_download(self):
+        """openmc.Materials are a container for openmc.Material objects. This
+        test checks that they are handeled correctly"""
 
         os.system('rm *.h5')
-        os.system('rm my_custom_nuclear_data_dir/*.h5')
+        os.system('rm my_custom_nuclear_data_with_materials/*.h5')
 
         # Define material
-        my_mat = openmc.openmc.Material()
-        my_mat.add_nuclide('Pu239', 3.7047e-2)
-        my_mat.add_nuclide('Pu240', 1.7512e-3)
-        my_mat.add_nuclide('As75', 1.3752e-3)
-        openmc.openmc.Materials([my_mat]).export_to_xml()
+        my_mat_1 = openmc.Material()
+        my_mat_1.add_nuclide('Pu239', 3.7047e-2)
+
+        my_mat_2 = openmc.Material()
+        my_mat_2.add_nuclide('Pu240', 1.7512e-3)
+        my_mat_2.add_nuclide('As75', 1.3752e-3)
+        mats = openmc.Materials([my_mat_1, my_mat_2]).export_to_xml()
 
         # Create a sphere of my_mat
-        surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
-        main_cell = openmc.Cell(fill=my_mat, region=-surf)
-        openmc.Geometry([main_cell]).export_to_xml()
+        surf_1 = openmc.Sphere(r=1)
+        surf_2 = openmc.Sphere(r=2, boundary_type='vacuum')
+        cell_1 = openmc.Cell(fill=my_mat_1, region=-surf_1)
+        cell_2 = openmc.Cell(fill=my_mat_1, region=surf_1 and -surf_2)
+        openmc.Geometry([cell_1, cell_2]).export_to_xml()
 
         # Define settings for the simulation
         settings = openmc.Settings()
-        settings.particles = 10
-        settings.batches = 2
+        settings.particles = 5
+        settings.batches = 3
         settings.inactive = 0
         center = (0., 0., 0.)
         settings.source = openmc.Source(space=openmc.stats.Point(center))
@@ -44,320 +50,370 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
         os.environ["OPENMC_CROSS_SECTIONS"] = ''
 
         just_in_time_library_generator(
-            destination='my_custom_nuclear_data_dir',
+            destination='my_custom_nuclear_data_with_materials',
             libraries=['TENDL-2019'],
-            materials=my_mat,
+            materials=mats,
             set_OPENMC_CROSS_SECTIONS=True
         )
 
         os.system('echo $OPENMC_CROSS_SECTIONS')
         openmc.run()
 
-        assert Path('my_custom_nuclear_data_dir/TENDL-2019_Pu239.h5').is_file()
-        assert Path('my_custom_nuclear_data_dir/TENDL-2019_Pu240.h5').is_file()
-        assert Path('my_custom_nuclear_data_dir/TENDL-2019_As75.h5').is_file()
+        assert Path('my_custom_nuclear_data_with_materials/TENDL-2019_Pu239.h5').is_file()
+        assert Path('my_custom_nuclear_data_with_materials/TENDL-2019_Pu240.h5').is_file()
+        assert Path('my_custom_nuclear_data_with_materials/TENDL-2019_As75.h5').is_file()
 
         assert Path('summary.h5').is_file()
-        assert Path('statepoint.2.h5').is_file()
-
-        assert len(list(Path('my_custom_nuclear_data_dir').glob('*.h5'))) == 3
-
-    def test_photon_simulation_with_single_mat(self):
-
-        os.system('rm *.h5')
-
-        # Define material
-        my_mat = openmc.openmc.Material()
-        my_mat.add_element('Fe', 1)
-        openmc.openmc.Materials([my_mat]).export_to_xml()
-
-        # Create a sphere of my_mat
-        surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
-        main_cell = openmc.Cell(fill=my_mat, region=-surf)
-        openmc.Geometry([main_cell]).export_to_xml()
-
-        # Define settings for the simulation
-        settings = openmc.Settings()
-        settings.particles = 10
-        settings.batches = 2
-        settings.inactive = 0
-        settings.run_mode = 'fixed source'
-        settings.photon_transport = True
-
-        source = openmc.Source()
-        source.space = openmc.stats.Point((0, 0, 0))
-        source.angle = openmc.stats.Isotropic()
-        # This is a Co60 source, see the task on sources to understand it
-        source.energy = openmc.stats.Discrete([1.1732e6], [1.])
-        source.particle = 'photon'
-
-        settings.source = source
-        settings.export_to_xml()
-
-        # this clears the enviromental varible just to be sure that current
-        # system settings are not being used
-        os.environ["OPENMC_CROSS_SECTIONS"] = ''
-
-        just_in_time_library_generator(
-            libraries=['FENDL-3.1d'],
-            materials=my_mat,
-            # TODO find out why neutrons are needed here
-            particles=['photon', 'neutron'],
-            set_OPENMC_CROSS_SECTIONS=True
-        )
-
-        os.system('echo $OPENMC_CROSS_SECTIONS')
-        openmc.run()
-
-        assert Path('FENDL-3.1d_Fe.h5').is_file()
-
-        assert Path('summary.h5').is_file()
-        assert Path('statepoint.2.h5').is_file()
-
-        # normally 3 if just photons used
-        assert len(list(Path('.').glob('*.h5'))) == 7
-
-    def test_photon_neutron_simulation_with_single_mat(self):
-
-        os.system('rm *.h5')
-
-        # Define material
-        my_mat = openmc.openmc.Material()
-        my_mat.add_element('Fe', 1)
-        openmc.openmc.Materials([my_mat]).export_to_xml()
-
-        # Create a sphere of my_mat
-        surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
-        main_cell = openmc.Cell(fill=my_mat, region=-surf)
-        openmc.Geometry([main_cell]).export_to_xml()
-
-        # Define settings for the simulation
-        settings = openmc.Settings()
-        settings.particles = 10
-        settings.batches = 2
-        settings.inactive = 0
-        settings.photon_transport = True
-        center = (0., 0., 0.)
-        settings.source = openmc.Source(space=openmc.stats.Point(center))
-        settings.run_mode = 'fixed source'
-        settings.export_to_xml()
-
-        # this clears the enviromental varible just to be sure that current
-        # system settings are not being used
-        os.environ["OPENMC_CROSS_SECTIONS"] = ''
-
-        just_in_time_library_generator(
-            libraries=['FENDL-3.1d'],
-            materials=my_mat,
-            particles=['neutron', 'photon'],
-            set_OPENMC_CROSS_SECTIONS=True
-        )
-
-        os.system('echo $OPENMC_CROSS_SECTIONS')
-        openmc.run()
-
-        assert Path('FENDL-3.1d_Fe54.h5').is_file()
-        assert Path('FENDL-3.1d_Fe56.h5').is_file()
-        assert Path('FENDL-3.1d_Fe57.h5').is_file()
-        assert Path('FENDL-3.1d_Fe58.h5').is_file()
-        assert Path('FENDL-3.1d_Fe.h5').is_file()
-
-        assert Path('summary.h5').is_file()
-        assert Path('statepoint.2.h5').is_file()
-        assert len(list(Path('.').glob('*.h5'))) == 7  # summary and statepoint
-
-    def test_simulation_with_single_mat(self):
-
-        os.system('rm *.h5')
-
-        # Define material
-        my_mat = openmc.openmc.Material()
-        my_mat.add_nuclide('Pu239', 3.7047e-2)
-        my_mat.add_nuclide('Pu240', 1.7512e-3)
-        my_mat.add_nuclide('As75', 1.3752e-3)
-        openmc.openmc.Materials([my_mat]).export_to_xml()
-
-        # Create a sphere of my_mat
-        surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
-        main_cell = openmc.Cell(fill=my_mat, region=-surf)
-        openmc.Geometry([main_cell]).export_to_xml()
-
-        # Define settings for the simulation
-        settings = openmc.Settings()
-        settings.particles = 10
-        settings.batches = 2
-        settings.inactive = 0
-        center = (0., 0., 0.)
-        settings.source = openmc.Source(space=openmc.stats.Point(center))
-        settings.export_to_xml()
-
-        # this clears the enviromental varible just to be sure that current
-        # system settings are not being used
-        os.environ["OPENMC_CROSS_SECTIONS"] = ''
-
-        just_in_time_library_generator(
-            libraries=['TENDL-2019'],
-            materials=my_mat,
-            particles='neutron',
-            set_OPENMC_CROSS_SECTIONS=True)
-
-        os.system('echo $OPENMC_CROSS_SECTIONS')
-        openmc.run()
-
-        assert Path('TENDL-2019_Pu239.h5').is_file()
-        assert Path('TENDL-2019_Pu240.h5').is_file()
-        assert Path('TENDL-2019_As75.h5').is_file()
-
-        assert Path('summary.h5').is_file()
-        assert Path('statepoint.2.h5').is_file()
-        assert len(list(Path('.').glob('*.h5'))) == 5  # summary and statepoint
-
-    def test_wmp_simulation_with_single_mat(self):
-
-        os.system('rm *.h5')
-
-        # Define material
-        my_mat = openmc.openmc.Material()
-        my_mat.add_nuclide('P31', 1)
-        my_mat.temperature = 400  # main_cell used instead
-        openmc.openmc.Materials([my_mat]).export_to_xml()
-
-        # Create a sphere of my_mat
-        surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
-        main_cell = openmc.Cell(fill=my_mat, region=-surf)
-        main_cell.temperature = 400
-        openmc.Geometry([main_cell]).export_to_xml()
-
-        # Define settings for the simulation
-        settings = openmc.Settings()
-        settings.particles = 10
-        settings.batches = 2
-        settings.inactive = 0
-        settings.photon_transport = False
-        center = (0., 0., 0.)
-        settings.source = openmc.Source(space=openmc.stats.Point(center))
-        settings.run_mode = 'fixed source'
-        settings.temperature = {'multipole': True}
-        settings.export_to_xml()
-
-        # this clears the enviromental varible just to be sure that current
-        # system settings are not being used
-        os.environ["OPENMC_CROSS_SECTIONS"] = ''
-
-        just_in_time_library_generator(
-            # 'ENDFB-7.1-NNDC' is needed as WMP simulations appear to require
-            # non WMP cross sections as well when simulating
-            # https://openmc.discourse.group/t/minimal-wmp-simulation-with-minimal-cross-section-xml/1100/7
-            libraries=['ENDFB-7.1-NNDC', 'ENDFB-7.1-WMP'],
-            materials=my_mat,
-            particles='neutron',
-            set_OPENMC_CROSS_SECTIONS=True)
-
-        os.system('echo $OPENMC_CROSS_SECTIONS')
-        openmc.run()
-
-        assert Path('ENDFB-7.1-WMP_P31.h5').is_file()
-
-        assert Path('summary.h5').is_file()
-        assert Path('statepoint.2.h5').is_file()
-        assert len(list(Path('.').glob('*.h5'))) == 3
-
-    def test_simulation_with_single_mat_list(self):
-
-        os.system('rm *.h5')
-
-        # Define material
-        my_mat = openmc.openmc.Material()
-        my_mat.add_nuclide('Pu239', 3.7047e-2)
-        my_mat.add_nuclide('Pu240', 1.7512e-3)
-        my_mat.add_nuclide('As75', 1.3752e-3)
-        openmc.openmc.Materials([my_mat]).export_to_xml()
-
-        # Create a sphere of my_mat
-        surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
-        main_cell = openmc.Cell(fill=my_mat, region=-surf)
-        openmc.Geometry([main_cell]).export_to_xml()
-
-        # Define settings for the simulation
-        settings = openmc.Settings()
-        settings.particles = 10
-        settings.batches = 2
-        settings.inactive = 0
-        center = (0., 0., 0.)
-        settings.source = openmc.Source(space=openmc.stats.Point(center))
-        settings.export_to_xml()
-
-        # this clears the enviromental varible just to be sure that current
-        # system settings are not being used
-        os.environ["OPENMC_CROSS_SECTIONS"] = ''
-
-        just_in_time_library_generator(
-            libraries=['TENDL-2019'],
-            materials=[my_mat],
-            particles='neutron',
-            set_OPENMC_CROSS_SECTIONS=True)
-
-        os.system('echo $OPENMC_CROSS_SECTIONS')
-        openmc.run()
-
-        assert Path('TENDL-2019_Pu239.h5').is_file()
-        assert Path('TENDL-2019_Pu240.h5').is_file()
-        assert Path('TENDL-2019_As75.h5').is_file()
-
-        assert Path('summary.h5').is_file()
-        assert Path('statepoint.2.h5').is_file()
-
-        assert len(list(Path('.').glob('*.h5'))) == 5  # summary and statepoint
-
-    def test_simulation_with_multi_mat_list(self):
-
-        os.system('rm *.h5')
-
-        # Define material
-        my_mat1 = openmc.openmc.Material()
-        my_mat1.add_nuclide('Pu239', 3.7047e-2)
-        my_mat1.add_nuclide('Pu240', 1.7512e-3)
-
-        my_mat2 = openmc.openmc.Material()
-        my_mat2.add_element('As', 1.3752e-3)
-        openmc.openmc.Materials([my_mat1, my_mat2]).export_to_xml()
-
-        # Create a sphere of my_mat
-        surf1 = openmc.Sphere(r=1)
-        surf2 = openmc.Sphere(r=6, boundary_type='vacuum')
-        main_cell = openmc.Cell(fill=my_mat1, region=-surf1)
-        outer_cell = openmc.Cell(fill=my_mat2, region=+surf1 & -surf2)
-        universe = openmc.Universe(cells=[main_cell, outer_cell])
-        openmc.Geometry(universe).export_to_xml()
-
-        # Define settings for the simulation
-        settings = openmc.Settings()
-        settings.particles = 10
-        settings.batches = 2
-        settings.inactive = 0
-        center = (0., 0., 0.)
-        settings.source = openmc.Source(space=openmc.stats.Point(center))
-        settings.export_to_xml()
-
-        # this clears the enviromental varible just to be sure that current
-        # system settings are not being used
-        os.environ["OPENMC_CROSS_SECTIONS"] = ''
-
-        just_in_time_library_generator(
-            libraries=['TENDL-2019'],
-            materials=[
-                my_mat1,
-                my_mat2],
-            set_OPENMC_CROSS_SECTIONS=True)
-
-        os.system('echo $OPENMC_CROSS_SECTIONS')
-        openmc.run()
-
-        assert Path('TENDL-2019_Pu239.h5').is_file()
-        assert Path('TENDL-2019_Pu240.h5').is_file()
-        assert Path('TENDL-2019_As75.h5').is_file()
-
-        assert Path('summary.h5').is_file()
-        assert Path('statepoint.2.h5').is_file()
-
-        assert len(list(Path('.').glob('*.h5'))) == 5  # summary and statepoint
+        assert Path('statepoint.3.h5').is_file()
+
+        assert len(list(Path('my_custom_nuclear_data_with_materials').glob('*.h5'))) == 3
+     
+
+    # def test_simulation_with_destination(self):
+
+    #     os.system('rm *.h5')
+    #     os.system('rm my_custom_nuclear_data_dir/*.h5')
+
+    #     # Define material
+    #     my_mat = openmc.openmc.Material()
+    #     my_mat.add_nuclide('Pu239', 3.7047e-2)
+    #     my_mat.add_nuclide('Pu240', 1.7512e-3)
+    #     my_mat.add_nuclide('As75', 1.3752e-3)
+    #     openmc.openmc.Materials([my_mat]).export_to_xml()
+
+    #     # Create a sphere of my_mat
+    #     surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
+    #     main_cell = openmc.Cell(fill=my_mat, region=-surf)
+    #     openmc.Geometry([main_cell]).export_to_xml()
+
+    #     # Define settings for the simulation
+    #     settings = openmc.Settings()
+    #     settings.particles = 10
+    #     settings.batches = 2
+    #     settings.inactive = 0
+    #     center = (0., 0., 0.)
+    #     settings.source = openmc.Source(space=openmc.stats.Point(center))
+    #     settings.export_to_xml()
+
+    #     # this clears the enviromental varible just to be sure that current
+    #     # system settings are not being used
+    #     os.environ["OPENMC_CROSS_SECTIONS"] = ''
+
+    #     just_in_time_library_generator(
+    #         destination='my_custom_nuclear_data_dir',
+    #         libraries=['TENDL-2019'],
+    #         materials=my_mat,
+    #         set_OPENMC_CROSS_SECTIONS=True
+    #     )
+
+    #     os.system('echo $OPENMC_CROSS_SECTIONS')
+    #     openmc.run()
+
+    #     assert Path('my_custom_nuclear_data_dir/TENDL-2019_Pu239.h5').is_file()
+    #     assert Path('my_custom_nuclear_data_dir/TENDL-2019_Pu240.h5').is_file()
+    #     assert Path('my_custom_nuclear_data_dir/TENDL-2019_As75.h5').is_file()
+
+    #     assert Path('summary.h5').is_file()
+    #     assert Path('statepoint.2.h5').is_file()
+
+    #     assert len(list(Path('my_custom_nuclear_data_dir').glob('*.h5'))) == 3
+
+    # def test_photon_simulation_with_single_mat(self):
+
+    #     os.system('rm *.h5')
+
+    #     # Define material
+    #     my_mat = openmc.openmc.Material()
+    #     my_mat.add_element('Fe', 1)
+    #     openmc.openmc.Materials([my_mat]).export_to_xml()
+
+    #     # Create a sphere of my_mat
+    #     surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
+    #     main_cell = openmc.Cell(fill=my_mat, region=-surf)
+    #     openmc.Geometry([main_cell]).export_to_xml()
+
+    #     # Define settings for the simulation
+    #     settings = openmc.Settings()
+    #     settings.particles = 10
+    #     settings.batches = 2
+    #     settings.inactive = 0
+    #     settings.run_mode = 'fixed source'
+    #     settings.photon_transport = True
+
+    #     source = openmc.Source()
+    #     source.space = openmc.stats.Point((0, 0, 0))
+    #     source.angle = openmc.stats.Isotropic()
+    #     # This is a Co60 source, see the task on sources to understand it
+    #     source.energy = openmc.stats.Discrete([1.1732e6], [1.])
+    #     source.particle = 'photon'
+
+    #     settings.source = source
+    #     settings.export_to_xml()
+
+    #     # this clears the enviromental varible just to be sure that current
+    #     # system settings are not being used
+    #     os.environ["OPENMC_CROSS_SECTIONS"] = ''
+
+    #     just_in_time_library_generator(
+    #         libraries=['FENDL-3.1d'],
+    #         materials=my_mat,
+    #         # TODO find out why neutrons are needed here
+    #         particles=['photon', 'neutron'],
+    #         set_OPENMC_CROSS_SECTIONS=True
+    #     )
+
+    #     os.system('echo $OPENMC_CROSS_SECTIONS')
+    #     openmc.run()
+
+    #     assert Path('FENDL-3.1d_Fe.h5').is_file()
+
+    #     assert Path('summary.h5').is_file()
+    #     assert Path('statepoint.2.h5').is_file()
+
+    #     # normally 3 if just photons used
+    #     assert len(list(Path('.').glob('*.h5'))) == 7
+
+    # def test_photon_neutron_simulation_with_single_mat(self):
+
+    #     os.system('rm *.h5')
+
+    #     # Define material
+    #     my_mat = openmc.openmc.Material()
+    #     my_mat.add_element('Fe', 1)
+    #     openmc.openmc.Materials([my_mat]).export_to_xml()
+
+    #     # Create a sphere of my_mat
+    #     surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
+    #     main_cell = openmc.Cell(fill=my_mat, region=-surf)
+    #     openmc.Geometry([main_cell]).export_to_xml()
+
+    #     # Define settings for the simulation
+    #     settings = openmc.Settings()
+    #     settings.particles = 10
+    #     settings.batches = 2
+    #     settings.inactive = 0
+    #     settings.photon_transport = True
+    #     center = (0., 0., 0.)
+    #     settings.source = openmc.Source(space=openmc.stats.Point(center))
+    #     settings.run_mode = 'fixed source'
+    #     settings.export_to_xml()
+
+    #     # this clears the enviromental varible just to be sure that current
+    #     # system settings are not being used
+    #     os.environ["OPENMC_CROSS_SECTIONS"] = ''
+
+    #     just_in_time_library_generator(
+    #         libraries=['FENDL-3.1d'],
+    #         materials=my_mat,
+    #         particles=['neutron', 'photon'],
+    #         set_OPENMC_CROSS_SECTIONS=True
+    #     )
+
+    #     os.system('echo $OPENMC_CROSS_SECTIONS')
+    #     openmc.run()
+
+    #     assert Path('FENDL-3.1d_Fe54.h5').is_file()
+    #     assert Path('FENDL-3.1d_Fe56.h5').is_file()
+    #     assert Path('FENDL-3.1d_Fe57.h5').is_file()
+    #     assert Path('FENDL-3.1d_Fe58.h5').is_file()
+    #     assert Path('FENDL-3.1d_Fe.h5').is_file()
+
+    #     assert Path('summary.h5').is_file()
+    #     assert Path('statepoint.2.h5').is_file()
+    #     assert len(list(Path('.').glob('*.h5'))) == 7  # summary and statepoint
+
+    # def test_simulation_with_single_mat(self):
+
+    #     os.system('rm *.h5')
+
+    #     # Define material
+    #     my_mat = openmc.openmc.Material()
+    #     my_mat.add_nuclide('Pu239', 3.7047e-2)
+    #     my_mat.add_nuclide('Pu240', 1.7512e-3)
+    #     my_mat.add_nuclide('As75', 1.3752e-3)
+    #     openmc.openmc.Materials([my_mat]).export_to_xml()
+
+    #     # Create a sphere of my_mat
+    #     surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
+    #     main_cell = openmc.Cell(fill=my_mat, region=-surf)
+    #     openmc.Geometry([main_cell]).export_to_xml()
+
+    #     # Define settings for the simulation
+    #     settings = openmc.Settings()
+    #     settings.particles = 10
+    #     settings.batches = 2
+    #     settings.inactive = 0
+    #     center = (0., 0., 0.)
+    #     settings.source = openmc.Source(space=openmc.stats.Point(center))
+    #     settings.export_to_xml()
+
+    #     # this clears the enviromental varible just to be sure that current
+    #     # system settings are not being used
+    #     os.environ["OPENMC_CROSS_SECTIONS"] = ''
+
+    #     just_in_time_library_generator(
+    #         libraries=['TENDL-2019'],
+    #         materials=my_mat,
+    #         particles='neutron',
+    #         set_OPENMC_CROSS_SECTIONS=True)
+
+    #     os.system('echo $OPENMC_CROSS_SECTIONS')
+    #     openmc.run()
+
+    #     assert Path('TENDL-2019_Pu239.h5').is_file()
+    #     assert Path('TENDL-2019_Pu240.h5').is_file()
+    #     assert Path('TENDL-2019_As75.h5').is_file()
+
+    #     assert Path('summary.h5').is_file()
+    #     assert Path('statepoint.2.h5').is_file()
+    #     assert len(list(Path('.').glob('*.h5'))) == 5  # summary and statepoint
+
+    # def test_wmp_simulation_with_single_mat(self):
+
+    #     os.system('rm *.h5')
+
+    #     # Define material
+    #     my_mat = openmc.openmc.Material()
+    #     my_mat.add_nuclide('P31', 1)
+    #     my_mat.temperature = 400  # main_cell used instead
+    #     openmc.openmc.Materials([my_mat]).export_to_xml()
+
+    #     # Create a sphere of my_mat
+    #     surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
+    #     main_cell = openmc.Cell(fill=my_mat, region=-surf)
+    #     main_cell.temperature = 400
+    #     openmc.Geometry([main_cell]).export_to_xml()
+
+    #     # Define settings for the simulation
+    #     settings = openmc.Settings()
+    #     settings.particles = 10
+    #     settings.batches = 2
+    #     settings.inactive = 0
+    #     settings.photon_transport = False
+    #     center = (0., 0., 0.)
+    #     settings.source = openmc.Source(space=openmc.stats.Point(center))
+    #     settings.run_mode = 'fixed source'
+    #     settings.temperature = {'multipole': True}
+    #     settings.export_to_xml()
+
+    #     # this clears the enviromental varible just to be sure that current
+    #     # system settings are not being used
+    #     os.environ["OPENMC_CROSS_SECTIONS"] = ''
+
+    #     just_in_time_library_generator(
+    #         # 'ENDFB-7.1-NNDC' is needed as WMP simulations appear to require
+    #         # non WMP cross sections as well when simulating
+    #         # https://openmc.discourse.group/t/minimal-wmp-simulation-with-minimal-cross-section-xml/1100/7
+    #         libraries=['ENDFB-7.1-NNDC', 'ENDFB-7.1-WMP'],
+    #         materials=my_mat,
+    #         particles='neutron',
+    #         set_OPENMC_CROSS_SECTIONS=True)
+
+    #     os.system('echo $OPENMC_CROSS_SECTIONS')
+    #     openmc.run()
+
+    #     assert Path('ENDFB-7.1-WMP_P31.h5').is_file()
+
+    #     assert Path('summary.h5').is_file()
+    #     assert Path('statepoint.2.h5').is_file()
+    #     assert len(list(Path('.').glob('*.h5'))) == 3
+
+    # def test_simulation_with_single_mat_list(self):
+
+    #     os.system('rm *.h5')
+
+    #     # Define material
+    #     my_mat = openmc.openmc.Material()
+    #     my_mat.add_nuclide('Pu239', 3.7047e-2)
+    #     my_mat.add_nuclide('Pu240', 1.7512e-3)
+    #     my_mat.add_nuclide('As75', 1.3752e-3)
+    #     openmc.openmc.Materials([my_mat]).export_to_xml()
+
+    #     # Create a sphere of my_mat
+    #     surf = openmc.Sphere(r=6.3849, boundary_type='vacuum')
+    #     main_cell = openmc.Cell(fill=my_mat, region=-surf)
+    #     openmc.Geometry([main_cell]).export_to_xml()
+
+    #     # Define settings for the simulation
+    #     settings = openmc.Settings()
+    #     settings.particles = 10
+    #     settings.batches = 2
+    #     settings.inactive = 0
+    #     center = (0., 0., 0.)
+    #     settings.source = openmc.Source(space=openmc.stats.Point(center))
+    #     settings.export_to_xml()
+
+    #     # this clears the enviromental varible just to be sure that current
+    #     # system settings are not being used
+    #     os.environ["OPENMC_CROSS_SECTIONS"] = ''
+
+    #     just_in_time_library_generator(
+    #         libraries=['TENDL-2019'],
+    #         materials=[my_mat],
+    #         particles='neutron',
+    #         set_OPENMC_CROSS_SECTIONS=True)
+
+    #     os.system('echo $OPENMC_CROSS_SECTIONS')
+    #     openmc.run()
+
+    #     assert Path('TENDL-2019_Pu239.h5').is_file()
+    #     assert Path('TENDL-2019_Pu240.h5').is_file()
+    #     assert Path('TENDL-2019_As75.h5').is_file()
+
+    #     assert Path('summary.h5').is_file()
+    #     assert Path('statepoint.2.h5').is_file()
+
+    #     assert len(list(Path('.').glob('*.h5'))) == 5  # summary and statepoint
+
+    # def test_simulation_with_multi_mat_list(self):
+
+    #     os.system('rm *.h5')
+
+    #     # Define material
+    #     my_mat1 = openmc.openmc.Material()
+    #     my_mat1.add_nuclide('Pu239', 3.7047e-2)
+    #     my_mat1.add_nuclide('Pu240', 1.7512e-3)
+
+    #     my_mat2 = openmc.openmc.Material()
+    #     my_mat2.add_element('As', 1.3752e-3)
+    #     openmc.openmc.Materials([my_mat1, my_mat2]).export_to_xml()
+
+    #     # Create a sphere of my_mat
+    #     surf1 = openmc.Sphere(r=1)
+    #     surf2 = openmc.Sphere(r=6, boundary_type='vacuum')
+    #     main_cell = openmc.Cell(fill=my_mat1, region=-surf1)
+    #     outer_cell = openmc.Cell(fill=my_mat2, region=+surf1 & -surf2)
+    #     universe = openmc.Universe(cells=[main_cell, outer_cell])
+    #     openmc.Geometry(universe).export_to_xml()
+
+    #     # Define settings for the simulation
+    #     settings = openmc.Settings()
+    #     settings.particles = 10
+    #     settings.batches = 2
+    #     settings.inactive = 0
+    #     center = (0., 0., 0.)
+    #     settings.source = openmc.Source(space=openmc.stats.Point(center))
+    #     settings.export_to_xml()
+
+    #     # this clears the enviromental varible just to be sure that current
+    #     # system settings are not being used
+    #     os.environ["OPENMC_CROSS_SECTIONS"] = ''
+
+    #     just_in_time_library_generator(
+    #         libraries=['TENDL-2019'],
+    #         materials=[
+    #             my_mat1,
+    #             my_mat2],
+    #         set_OPENMC_CROSS_SECTIONS=True)
+
+    #     os.system('echo $OPENMC_CROSS_SECTIONS')
+    #     openmc.run()
+
+    #     assert Path('TENDL-2019_Pu239.h5').is_file()
+    #     assert Path('TENDL-2019_Pu240.h5').is_file()
+    #     assert Path('TENDL-2019_As75.h5').is_file()
+
+    #     assert Path('summary.h5').is_file()
+    #     assert Path('statepoint.2.h5').is_file()
+
+    #     assert len(list(Path('.').glob('*.h5'))) == 5  # summary and statepoint

--- a/tests/test_use_in_openmc.py
+++ b/tests/test_use_in_openmc.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import openmc
 from openmc_data_downloader import just_in_time_library_generator
+import openmc_data_downloader
 
 
 class test_usage_with_openmc_python_api(unittest.TestCase):
@@ -422,3 +423,18 @@ class test_usage_with_openmc_python_api(unittest.TestCase):
         assert Path('statepoint.2.h5').is_file()
 
         assert len(list(Path('.').glob('*.h5'))) == 5  # summary and statepoint
+
+    def test_incorrect_expand_materials_to_isotopes_with_inccorect_args(self):
+        """Checks than an error is raised when incorrect values of materials
+        are passed"""
+
+        def incorrect_material_type():
+            openmc_data_downloader.expand_materials_to_isotopes(1)
+
+        self.assertRaises(incorrect_material_type)
+
+        def incorrect_materials_list_type():
+            openmc_data_downloader.expand_materials_to_isotopes([1, 2, 3])
+
+        self.assertRaises(incorrect_material_type, ValueError)
+        self.assertRaises(incorrect_materials_list_type, ValueError)


### PR DESCRIPTION
Adds support for openmc.Materials to the just_in_time_library_generator.

openmc.Materials are basically a list of openmc.Material objects so this is quite a small addition that makes useage a little more convenient

Requested in issue #7 